### PR TITLE
applying GSD's error-surfacing changes to surface errors in SignIn object

### DIFF
--- a/buildtools/templates/index.tpl
+++ b/buildtools/templates/index.tpl
@@ -17,6 +17,12 @@
     var options = {{{options}}};
     var signIn = new OktaSignIn(options);
 
+    signIn.on('authError', function (err) {
+      if (err.name=='AuthApiError') {
+        console.log(err);
+      }
+    });
+
     signIn.renderEl(
       { el: '#okta-login-container' },
 

--- a/src/models/PrimaryAuth.js
+++ b/src/models/PrimaryAuth.js
@@ -131,7 +131,8 @@ function (Okta, BaseLoginModel, CookieUtil, Enums) {
       }
 
       return primaryAuthPromise
-      .fail(_.bind(function () {
+      .fail(_.bind(function (e) {
+        this.trigger('error', e);
         this.trigger('error');
         // Specific event handled by the Header for the case where the security image is not
         // enabled and we want to show a spinner. (Triggered only here and handled only by Header).

--- a/src/util/BaseLoginController.js
+++ b/src/util/BaseLoginController.js
@@ -47,8 +47,11 @@ define(['okta', 'vendor/lib/q'], function (Okta, Q) {
         this.toggleButtonState(true);
       });
 
-      this.listenTo(this.model, 'error', function () {
+      this.listenTo(this.model, 'error', function (e) {
         this.toggleButtonState(false);
+        if (e && e.name=='AuthApiError') {
+          this.trigger('authError', e);
+        }
       });
 
       var setTransactionHandler = _.bind(function (transaction) {


### PR DESCRIPTION
This is the error-reporting change that GSD applied in order to surface errors from the SignIn object, that they can then listen to, in order to act on externally: https://github.com/kazpsp/oktactl/commit/7f0b3743f6af2b111c2d5b4e6c33701281972e75

Applied to the current master branch (v2.2): https://github.com/okta/okta-signin-widget/tree/2.2